### PR TITLE
EE-792: Add `asc` AssemblyScript compiler globally

### DIFF
--- a/init-buildenv
+++ b/init-buildenv
@@ -43,8 +43,16 @@ chmod +x /usr/local/bin/docker-compose
 curl -sL https://deb.nodesource.com/setup_12.x | bash -
 apt-get install -y nodejs
 
-# add link checker plugins to npm
-npm install --global remark-cli remark-validate-links remark-lint-no-dead-urls
+NODE_PACKAGES=(
+	# add link checker plugins to npm
+	remark-cli
+	remark-validate-links
+	remark-lint-no-dead-urls
+	# install assemblyscript compiler
+	assemblyscript
+)
+
+npm install --global "${NODE_PACKAGES[@]}"
 
 PACKAGES=(
 	# utilities for debugging


### PR DESCRIPTION
Contracts written in AssemblyScript will depend on it, so having a global `asc` for those contracts will make us avoid having `node_modules` per contract and should decrease TS contracts build times.