### PR TITLE
Pin assemblyscript compiler to 0.9.1

### DIFF
--- a/init-buildenv
+++ b/init-buildenv
@@ -49,7 +49,7 @@ NODE_PACKAGES=(
 	remark-validate-links
 	remark-lint-no-dead-urls
 	# install assemblyscript compiler
-	assemblyscript
+	"assemblyscript@0.9.1"
 )
 
 npm install --global "${NODE_PACKAGES[@]}"


### PR DESCRIPTION
AssemblyScript changes really fast and I learned that the changes are backwards incompatible to say the least. I'm pinning it to 0.9.1 to avoid further problems and make the code upgrades a manual process.