### PR TITLE
install dependencies for cargo-audit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN apt -y install \
               curl moreutils netcat-openbsd nmap openssh-server psmisc screen socat tmux wget \
               java-common jflex openjdk-11-jdk-headless openjdk-8-jdk-headless sbt=1.\* \
               protobuf-compiler libprotobuf-dev cmake python3 python3-pip \
-              docker-ce rpm fakeroot lintian nodejs rsync locales
+              docker-ce rpm fakeroot lintian nodejs rsync locales libssl-dev pkg-config
 
 RUN apt clean
 


### PR DESCRIPTION
This will allow us to install `cargo-audit` as per [EE-903](https://casperlabs.atlassian.net/browse/EE-903) for use in our CI pipeline.