### PR TITLE
NODE-1297: Fix buildenv for Python client ("Python.h: No such file or directory")

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ RUN . ~/.rust_env; cargo +${RUST_TOOLCHAIN} install cargo-deb
 RUN apt -y install \
               curl moreutils netcat-openbsd nmap openssh-server psmisc screen socat tmux wget \
               java-common jflex openjdk-11-jdk-headless openjdk-8-jdk-headless sbt=1.\* \
-              protobuf-compiler libprotobuf-dev cmake python3.7 python3-pip \
+              protobuf-compiler libprotobuf-dev cmake python3.7 libpython3.7-dev python3-pip \
               docker-ce rpm fakeroot lintian nodejs rsync locales libssl-dev pkg-config
 
 RUN apt clean


### PR DESCRIPTION
Install libpython3.7-dev in order to fix "fatal error: Python.h: No such file or directory" during compilation of C extension of a Pythonn crypto lib (ed25519)

This is hopefully fix for:
https://drone-auto.casperlabs.io/CasperLabs/CasperLabs/13007/1/2
that happens on PR that migrates to Python 3.7