### PR TITLE
Removing old CasperLabs repo reference for toolchain with proper casper-node ref.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -6,90 +6,6 @@ clone:
     image: plugins/git:next
 
 pipeline:
-  build-buildenv:
-    image: docker:stable
-    commands:
-      - apk add git bash
-      - ./update-images.sh buildenv
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-    when:
-      changeset:
-        includes:
-          - "buildenv/**"
-
-  push-image-buildenv:
-    image: docker:stable
-    commands:
-      - apk add git bash
-      - ./push-docker.sh buildenv
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-    secrets:
-      - docker_username
-      - docker_password
-    when:
-      event: [ push, tag ]
-      changeset:
-        includes:
-          - "buildenv/**"
-
-  build-node-build-u1804:
-    image: docker:stable
-    commands:
-      - apk add git bash
-      - ./update-images.sh node-build-u1804
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-    when:
-      changeset:
-        includes:
-          - "node-build-u1804/**"
-
-  push-image-node-build-u1804:
-    image: docker:stable
-    commands:
-      - apk add git bash
-      - ./push-docker.sh node-build-u1804
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-    secrets:
-      - docker_username
-      - docker_password
-    when:
-      event: [ push, tag ]
-      changeset:
-        includes:
-          - "node-build-u1804/**"
-
-  build-node-build-u2004:
-    image: docker:stable
-    commands:
-      - apk add git bash
-      - ./update-images.sh node-build-u2004
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-    when:
-      changeset:
-        includes:
-          - "node-build-u2004/**"
-
-  push-image-node-build-u2004:
-    image: docker:stable
-    commands:
-      - apk add git bash
-      - ./push-docker.sh node-build-u2004
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-    secrets:
-      - docker_username
-      - docker_password
-    when:
-      event: [ push, tag ]
-      changeset:
-        includes:
-          - "node-build-u2004/**"
-
   build-s3cmd-image:
     image: docker:stable
     commands:
@@ -100,7 +16,7 @@ pipeline:
     when:
       changeset:
         includes:
-          - "s3cmd-build/**"
+          - "**/s3cmd-build/Dockerfile"
 
   push-image-s3cmd:
     image: docker:stable
@@ -116,7 +32,91 @@ pipeline:
       event: [ push, tag ]
       changeset:
         includes:
-          - "s3cmd-build/**"
+          - "**/s3cmd-build/Dockerfile"
+
+  build-buildenv:
+    image: docker:stable
+    commands:
+      - apk add git bash
+      - ./update-images.sh buildenv
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    when:
+      changeset:
+        includes:
+          - "**/buildenv/**"
+
+  push-image-buildenv:
+    image: docker:stable
+    commands:
+      - apk add git bash
+      - ./push-docker.sh buildenv
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    secrets:
+      - docker_username
+      - docker_password
+    when:
+      event: [ push, tag ]
+      changeset:
+        includes:
+          - "**/buildenv/**"
+
+  build-node-build-u1804:
+    image: docker:stable
+    commands:
+      - apk add git bash
+      - ./update-images.sh node-build-u1804
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    when:
+      changeset:
+        includes:
+          - "**/node-build-u1804/Dockerfile"
+
+  push-image-node-build-u1804:
+    image: docker:stable
+    commands:
+      - apk add git bash
+      - ./push-docker.sh node-build-u1804
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    secrets:
+      - docker_username
+      - docker_password
+    when:
+      event: [ push, tag ]
+      changeset:
+        includes:
+          - "**/node-build-u2004/Dockerfile"
+
+  build-node-build-u2004:
+    image: docker:stable
+    commands:
+      - apk add git bash
+      - ./update-images.sh node-build-u2004
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    when:
+      changeset:
+        includes:
+          - "**/node-build-u2004/Dockerfile"
+
+  push-image-node-build-u2004:
+    image: docker:stable
+    commands:
+      - apk add git bash
+      - ./push-docker.sh node-build-u2004
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    secrets:
+      - docker_username
+      - docker_password
+    when:
+      event: [ push, tag ]
+      changeset:
+        includes:
+          - "**/node-build-u2004/Dockerfile"
 
   notify:
     image: plugins/slack

--- a/.drone.yml
+++ b/.drone.yml
@@ -16,7 +16,7 @@ pipeline:
     when:
       changeset:
         includes:
-          - "**./buildenv/*"
+          - "buildenv/**"
 
   push-image-buildenv:
     image: docker:stable
@@ -32,7 +32,7 @@ pipeline:
       event: [ push, tag ]
       changeset:
         includes:
-          - "**./buildenv/*"
+          - "buildenv/**"
 
   build-node-build-u1804:
     image: docker:stable
@@ -44,7 +44,7 @@ pipeline:
     when:
       changeset:
         includes:
-          - "**./node-build-u1804/*"
+          - "node-build-u1804/**"
 
   push-image-node-build-u1804:
     image: docker:stable
@@ -60,7 +60,7 @@ pipeline:
       event: [ push, tag ]
       changeset:
         includes:
-          - "**./node-build-u1804/*"
+          - "node-build-u1804/**"
 
   build-node-build-u2004:
     image: docker:stable
@@ -72,7 +72,7 @@ pipeline:
     when:
       changeset:
         includes:
-          - "**./node-build-u2004/*"
+          - "node-build-u2004/**"
 
   push-image-node-build-u2004:
     image: docker:stable
@@ -88,7 +88,7 @@ pipeline:
       event: [ push, tag ]
       changeset:
         includes:
-          - "**./node-build-u2004/*"
+          - "node-build-u2004/**"
 
   build-s3cmd-image:
     image: docker:stable
@@ -100,7 +100,7 @@ pipeline:
     when:
       changeset:
         includes:
-          - "**./s3cmd-build/*"
+          - "s3cmd-build/**"
 
   push-image-s3cmd:
     image: docker:stable
@@ -116,7 +116,7 @@ pipeline:
       event: [ push, tag ]
       changeset:
         includes:
-          - "**./s3cmd-build/*"
+          - "s3cmd-build/**"
 
   notify:
     image: plugins/slack

--- a/.drone.yml
+++ b/.drone.yml
@@ -113,6 +113,7 @@ pipeline:
       - docker_username
       - docker_password
     when:
+      event: [ push, tag ]
       changeset:
         includes:
           - "**./s3cmd-build/*"

--- a/.drone.yml
+++ b/.drone.yml
@@ -6,34 +6,6 @@ clone:
     image: plugins/git:next
 
 pipeline:
-  build-s3cmd-image:
-    image: docker:stable
-    commands:
-      - apk add git bash
-      - ./update-images.sh s3cmd-build
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-    when:
-      changeset:
-        includes:
-          - "**/s3cmd-build/Dockerfile"
-
-  push-image-s3cmd:
-    image: docker:stable
-    commands:
-      - apk add git bash
-      - ./push-docker.sh s3cmd-build
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-    secrets:
-      - docker_username
-      - docker_password
-    when:
-      event: [ push, tag ]
-      changeset:
-        includes:
-          - "**/s3cmd-build/Dockerfile"
-
   build-buildenv:
     image: docker:stable
     commands:
@@ -41,10 +13,6 @@ pipeline:
       - ./update-images.sh buildenv
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-    when:
-      changeset:
-        includes:
-          - "**/buildenv/**"
 
   push-image-buildenv:
     image: docker:stable
@@ -58,9 +26,6 @@ pipeline:
       - docker_password
     when:
       event: [ push, tag ]
-      changeset:
-        includes:
-          - "**/buildenv/**"
 
   build-node-build-u1804:
     image: docker:stable
@@ -69,10 +34,6 @@ pipeline:
       - ./update-images.sh node-build-u1804
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-    when:
-      changeset:
-        includes:
-          - "**/node-build-u1804/Dockerfile"
 
   push-image-node-build-u1804:
     image: docker:stable
@@ -86,9 +47,6 @@ pipeline:
       - docker_password
     when:
       event: [ push, tag ]
-      changeset:
-        includes:
-          - "**/node-build-u2004/Dockerfile"
 
   build-node-build-u2004:
     image: docker:stable
@@ -97,10 +55,6 @@ pipeline:
       - ./update-images.sh node-build-u2004
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-    when:
-      changeset:
-        includes:
-          - "**/node-build-u2004/Dockerfile"
 
   push-image-node-build-u2004:
     image: docker:stable
@@ -114,9 +68,27 @@ pipeline:
       - docker_password
     when:
       event: [ push, tag ]
-      changeset:
-        includes:
-          - "**/node-build-u2004/Dockerfile"
+
+  build-s3cmd-image:
+    image: docker:stable
+    commands:
+      - apk add git bash
+      - ./update-images.sh s3cmd-build
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
+  push-image-s3cmd:
+    image: docker:stable
+    commands:
+      - apk add git bash
+      - ./push-docker.sh s3cmd-build
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    secrets:
+      - docker_username
+      - docker_password
+    when:
+      event: [ push, tag ]
 
   notify:
     image: plugins/slack

--- a/buildenv/Dockerfile
+++ b/buildenv/Dockerfile
@@ -35,7 +35,7 @@ RUN curl -f -L https://static.rust-lang.org/rustup.sh -O
 RUN sh rustup.sh -y
 ENV PATH="$PATH:/root/.cargo/bin"
 
-RUN echo export RUST_TOOLCHAIN=$(curl -s https://raw.githubusercontent.com/CasperLabs/CasperLabs/dev/execution-engine/rust-toolchain) >> ~/.rust_env
+RUN echo export RUST_TOOLCHAIN=$(curl -s https://raw.githubusercontent.com/CasperLabs/casper-node/master/rust-toolchain) >> ~/.rust_env
 
 RUN . ~/.rust_env; rustup toolchain install "${RUST_TOOLCHAIN}"
 RUN . ~/.rust_env; rustup toolchain install stable

--- a/node-build-u1804/Dockerfile
+++ b/node-build-u1804/Dockerfile
@@ -19,7 +19,7 @@ RUN curl -f -L https://static.rust-lang.org/rustup.sh -O \
     && sh rustup.sh -y
 ENV PATH="$PATH:/root/.cargo/bin"
 
-RUN echo export RUST_TOOLCHAIN=$(curl -s https://raw.githubusercontent.com/CasperLabs/CasperLabs/dev/execution-engine/rust-toolchain) >> ~/.rust_env \
+RUN echo export RUST_TOOLCHAIN=$(curl -s https://raw.githubusercontent.com/CasperLabs/casper-node/master/rust-toolchain) >> ~/.rust_env \
     && . ~/.rust_env; rustup toolchain install "${RUST_TOOLCHAIN}" \
     && . ~/.rust_env; rustup toolchain install stable \
     && rustup update \

--- a/node-build-u2004/Dockerfile
+++ b/node-build-u2004/Dockerfile
@@ -21,7 +21,7 @@ RUN curl -f -L https://static.rust-lang.org/rustup.sh -O \
     && sh rustup.sh -y
 ENV PATH="$PATH:/root/.cargo/bin"
 
-RUN echo export RUST_TOOLCHAIN=$(curl -s https://raw.githubusercontent.com/CasperLabs/CasperLabs/dev/execution-engine/rust-toolchain) >> ~/.rust_env \
+RUN echo export RUST_TOOLCHAIN=$(curl -s https://raw.githubusercontent.com/CasperLabs/casper-node/master/rust-toolchain) >> ~/.rust_env \
     && . ~/.rust_env; rustup toolchain install "${RUST_TOOLCHAIN}" \
     && . ~/.rust_env; rustup toolchain install stable \
     && rustup update \


### PR DESCRIPTION
Update to pull the toolchain defined in casper-node instead of CasperLabs.  
Also updating the s3cmd image to publish only on push and tag.