### PR TITLE
Updating clarity-build with make and reducing buildenv

### DIFF
--- a/buildenv/Dockerfile
+++ b/buildenv/Dockerfile
@@ -75,12 +75,6 @@ RUN pip3 install docker delayed_assert pipenv pytest typing_extensions grpcio gr
 
 RUN sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen && locale-gen
 
-RUN git clone https://github.com/CasperLabs/CasperLabs.git ~/CasperLabs
-RUN cd ~/CasperLabs && sbt update
-RUN cd ~/CasperLabs/execution-engine && make setup
-RUN cd ~/CasperLabs/execution-engine && ~/.cargo/bin/cargo fetch
-RUN rm -rf ~/CasperLabs
-
 ENV LC_ALL en_US.UTF-8
 
 ADD bintray/ /opt/bintray/

--- a/clarity-build/Dockerfile
+++ b/clarity-build/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:12.5.0-stretch-slim
 
-RUN apt-get update && apt-get install -y git docker
+RUN apt-get update && apt-get install -y git docker make
 RUN npm install --global yarn
 RUN yarn global add lerna


### PR DESCRIPTION
Adding make to clarity-build.
Removing CasperLabs clone so we can go private.