### PR TITLE
NO-TICK: casper-node-launcher-build

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -6,19 +6,19 @@ clone:
     image: plugins/git:next
 
 pipeline:
-  build-buildenv:
+  build-casper-node-launcher-build:
     image: docker:stable
     commands:
       - apk add git bash
-      - ./update-images.sh buildenv
+      - ./update-images.sh casper-node-launcher-build
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
 
-  push-image-buildenv:
+  push-image-casper-node-launcher-build:
     image: docker:stable
     commands:
       - apk add git bash
-      - ./push-docker.sh buildenv
+      - ./push-docker.sh casper-node-launcher-build
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     secrets:

--- a/casper-node-launcher-build/Dockerfile
+++ b/casper-node-launcher-build/Dockerfile
@@ -1,0 +1,21 @@
+# Container for debian packaging CasperLabs
+# bionic = 18.04
+FROM ubuntu:bionic
+
+RUN apt-get update \
+    && apt-get install -y curl gnupg gcc git ca-certificates \
+              pkg-config jq gettext-base python3.6 python3-pip
+
+# toml for publish script
+RUN pip3 install toml
+
+# install cmake
+RUN curl -Ls https://github.com/Kitware/CMake/releases/download/v3.17.3/cmake-3.17.3-Linux-x86_64.tar.gz | tar -C /usr/local --strip-components=1 -xz
+
+RUN curl -f -L https://static.rust-lang.org/rustup.sh -O \
+    && sh rustup.sh -y
+ENV PATH="$PATH:/root/.cargo/bin"
+
+RUN rustup toolchain install stable \
+    && rustup update \
+    && cargo +stable install cargo-deb


### PR DESCRIPTION
Added casper-node-launcher-build to isolate from node-u1804-build as we may have incompatibilites.
Removed buildenv as we will remove from signer, the last repo.