### PR TITLE
using rockylinux build test ok as centos8 is EOL

### DIFF
--- a/rpm-package/Dockerfile
+++ b/rpm-package/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:centos8
+FROM rockylinux:8
 
 # Required to not have issues with cmake.
 # cmake: symbol lookup error: cmake: undefined symbol: archive_write_add_filter_zstd


### PR DESCRIPTION
CentOS 8 is now dead. The image cannot be rebuilt with the same centos8 base.
After testing alternatives (RH UBI and Oracle Linux) found rockylinux to be the most suitable.

The build has been tested ok.