### PR TITLE
CI: move all rust to single layer

### DIFF
--- a/node-build-u1804/Dockerfile
+++ b/node-build-u1804/Dockerfile
@@ -24,6 +24,7 @@ RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - \
 RUN python3 -m pip install supervisor toml
 
 RUN curl -f -L https://static.rust-lang.org/rustup.sh -O \
+    && source $HOME/.cargo/env \
     && sh rustup.sh -y \
     && rustup update \
     && rustup toolchain install stable \

--- a/node-build-u1804/Dockerfile
+++ b/node-build-u1804/Dockerfile
@@ -24,15 +24,14 @@ RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - \
 RUN python3 -m pip install supervisor toml
 
 RUN curl -f -L https://static.rust-lang.org/rustup.sh -O \
-    && sh rustup.sh -y
-ENV PATH="$PATH:/root/.cargo/bin"
-
-RUN rustup toolchain install stable \
+    && sh rustup.sh -y \
     && rustup update \
+    && rustup toolchain install stable \
     && cargo install cargo-deb \
     && cargo install cargo-audit \
     && cargo install cargo-rpm \
     && cargo install --git https://github.com/paritytech/cachepot --branch master
+ENV PATH="$PATH:/root/.cargo/bin"
 
 RUN git clone https://github.com/casper-network/casper-node.git ~/casper-node \
     && cd ~/casper-node \

--- a/node-build-u1804/Dockerfile
+++ b/node-build-u1804/Dockerfile
@@ -23,8 +23,8 @@ RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - \
 
 RUN python3 -m pip install supervisor toml
 
+ENV PATH="$PATH:/root/.cargo/bin"
 RUN curl -f -L https://static.rust-lang.org/rustup.sh -O \
-    && source $HOME/.cargo/env \
     && sh rustup.sh -y \
     && rustup update \
     && rustup toolchain install stable \
@@ -32,7 +32,6 @@ RUN curl -f -L https://static.rust-lang.org/rustup.sh -O \
     && cargo install cargo-audit \
     && cargo install cargo-rpm \
     && cargo install --git https://github.com/paritytech/cachepot --branch master
-ENV PATH="$PATH:/root/.cargo/bin"
 
 RUN git clone https://github.com/casper-network/casper-node.git ~/casper-node \
     && cd ~/casper-node \


### PR DESCRIPTION
casper-test has been failing when running `rustup update` due to rustup being updated in a new layer. This is an attempt to fix that error from happening.

Related: 
- https://github.com/rust-lang/rustup/issues/2232 (see kinnison's comment)
- https://drone-auto-casper-network.casperlabs.io/casper-network/casper-test/315/1/2